### PR TITLE
fix: updated dutotone/time.svg for 64px and 96px

### DIFF
--- a/src/manifest/updated-icons.txt
+++ b/src/manifest/updated-icons.txt
@@ -63,4 +63,4 @@ branch
 Book
 Billing
 Arrows-vertical
-Aperture
+aperture

--- a/src/svg/duotone/64/time.svg
+++ b/src/svg/duotone/64/time.svg
@@ -1,6 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="none" viewBox="0 0 64 64">
-  <g fill-rule="evenodd" class="time" clip-rule="evenodd">
-    <path fill="#3D3C3C" d="M4 32C4 16.53 16.53 4 32 4s28 12.53 28 28-12.53 28-28 28S4 47.47 4 32ZM32 6C17.635 6 6 17.635 6 32s11.635 26 26 26 26-11.635 26-26S46.365 6 32 6Z" class="primary"/>
-    <path fill="#FF462D" d="M32 13a1 1 0 0 1 1 1v17h13a1 1 0 1 1 0 2H32a1 1 0 0 1-1-1V14a1 1 0 0 1 1-1Z" class="secondary"/>
+  <g class="Size=M">
+    <g fill-rule="evenodd" class="Icon" clip-rule="evenodd">
+      <path fill="#3D3C3C" d="M4 32C4 16.53 16.53 4 32 4s28 12.53 28 28-12.53 28-28 28S4 47.47 4 32ZM32 6C17.635 6 6 17.635 6 32s11.635 26 26 26 26-11.635 26-26S46.365 6 32 6Z" class="primary"/>
+      <path fill="#FF462D" d="M33 14a1 1 0 1 0-2 0v17.982a.996.996 0 0 0 .457.858l8.988 5.992a1 1 0 0 0 1.11-1.664L33 31.465V14Z" class="secondary"/>
+    </g>
   </g>
 </svg>

--- a/src/svg/duotone/96/time.svg
+++ b/src/svg/duotone/96/time.svg
@@ -1,6 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" fill="none" viewBox="0 0 96 96">
-  <g fill-rule="evenodd" class="time" clip-rule="evenodd">
-    <path fill="#3D3C3C" d="M8 48C8 25.9 25.9 8 48 8s40 17.9 40 40-17.9 40-40 40S8 70.1 8 48Zm40-38c-20.995 0-38 17.005-38 38s17.005 38 38 38 38-17.005 38-38-17.005-38-38-38Z" class="primary"/>
-    <path fill="#FF462D" d="M48 21a1 1 0 0 1 1 1v25h19a1 1 0 1 1 0 2H48a1 1 0 0 1-1-1V22a1 1 0 0 1 1-1Z" class="secondary"/>
+  <g class="Size=L">
+    <g fill-rule="evenodd" class="Icon" clip-rule="evenodd">
+      <path fill="#3D3C3C" d="M8 48C8 25.9 25.9 8 48 8s40 17.9 40 40-17.9 40-40 40S8 70.1 8 48Zm40-38c-20.995 0-38 17.005-38 38s17.005 38 38 38 38-17.005 38-38-17.005-38-38-38Z" class="primary"/>
+      <path fill="#FF462D" d="M49 22a1 1 0 1 0-2 0v26c0 .042.002.084.008.124a1 1 0 0 0 .437.958l13.125 8.75a1 1 0 0 0 1.11-1.664L49 47.715V22Z" class="secondary"/>
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

updated dutotone/time.svg for 64px and 96px

## Figma Link

https://www.figma.com/design/ZNudJzPCnqRpzUEnDatcMb/Shidoka-Icon-Library?node-id=2597-7939&m=dev