### PR TITLE
fix(chai): enabled duotone for box-empty,error, data-search, no-access

### DIFF
--- a/src/manifest/icons.json
+++ b/src/manifest/icons.json
@@ -832,13 +832,6 @@
     "duotone": true
   },
   {
-    "name": "box-empty",
-    "friendly_name": "Box Empty",
-    "category": "Functional",
-    "aliases": [],
-    "duotone": true
-  },
-  {
     "name": "attachment",
     "friendly_name": "Attachment",
     "category": "Functional",
@@ -991,7 +984,7 @@
       "vacant",
       "zero-inventory"
     ],
-    "duotone": false
+    "duotone": true
   },
   {
     "name": "box-search",
@@ -2688,13 +2681,6 @@
     "duotone": true
   },
   {
-    "name": "data-search",
-    "friendly_name": "Data Search",
-    "category": "Functional",
-    "aliases": [],
-    "duotone": true
-  },
-  {
     "name": "data-center",
     "friendly_name": "Data Center",
     "category": "Services",
@@ -2726,7 +2712,7 @@
     "friendly_name": "Data Search",
     "category": "Functional",
     "aliases": ["data", "search", "find", "lookup", "query"],
-    "duotone": false
+    "duotone": true
   },
   {
     "name": "database-2",
@@ -3525,13 +3511,6 @@
     "duotone": true
   },
   {
-    "name": "error",
-    "friendly_name": "Error",
-    "category": "Functional",
-    "aliases": [],
-    "duotone": true
-  },
-  {
     "name": "erase",
     "friendly_name": "Erase",
     "category": "Functional",
@@ -3564,7 +3543,7 @@
       "alert",
       "status-error"
     ],
-    "duotone": false
+    "duotone": true
   },
   {
     "name": "error-2",
@@ -5122,7 +5101,7 @@
       "permission-denied",
       "prohibited"
     ],
-    "duotone": false
+    "duotone": true
   },
   {
     "name": "no-connection",


### PR DESCRIPTION
## Summary

Enabled duotone for box-empty,error, data-search, no-access

## ADO Story or GitHub Issue Link

Link here (if applicable).

## Figma Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [ ] Exported all SVG files using the Figma SVG Export plugin with the Monochrome and Duotone presets.
- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
  - [ ] Identified deprecated features (if any).

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
